### PR TITLE
`from __future__ import annotations`を除去する

### DIFF
--- a/annoworkapi/actual_working_time.py
+++ b/annoworkapi/actual_working_time.py
@@ -1,7 +1,7 @@
 """
 実績作業時間に関するutil関数を定義しています。
 """
-from __future__ import annotations
+
 
 import datetime
 from collections import defaultdict

--- a/annoworkapi/annofab.py
+++ b/annoworkapi/annofab.py
@@ -1,7 +1,7 @@
 """
 外部連携システム"Annofab"に依存した関数やクラスを定義しています。
 """
-from __future__ import annotations
+
 
 from collections import defaultdict
 from typing import Any, Collection, Optional

--- a/annoworkapi/api.py
+++ b/annoworkapi/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import copy
 import functools
 import json

--- a/annoworkapi/enums.py
+++ b/annoworkapi/enums.py
@@ -9,7 +9,6 @@ enumならば列挙体として定義する。
 Note:
     このファイルはopenapi-generatorで自動生成される。
 """
-from __future__ import annotations
 
 import warnings  # pylint: disable=unused-import
 from enum import Enum

--- a/annoworkapi/generated_api.py
+++ b/annoworkapi/generated_api.py
@@ -7,7 +7,6 @@ AbstractAnnoworkApiのヘッダ部分
 Note:
     このファイルはopenapi-generatorで自動生成される。詳細は generate/README.mdを参照
 """
-from __future__ import annotations
 
 import abc
 import warnings  # pylint: disable=unused-import

--- a/annoworkapi/schedule.py
+++ b/annoworkapi/schedule.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime
 from typing import Any, Dict, Generator, Tuple
 

--- a/annoworkapi/utils.py
+++ b/annoworkapi/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime
 
 

--- a/annoworkapi/wrapper.py
+++ b/annoworkapi/wrapper.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime
 import logging
 from collections import defaultdict

--- a/generate/partial-header/generated_api_partial_header.py
+++ b/generate/partial-header/generated_api_partial_header.py
@@ -7,7 +7,7 @@ AbstractAnnoworkApiのヘッダ部分
 Note:
     このファイルはopenapi-generatorで自動生成される。詳細は generate/README.mdを参照
 """
-from __future__ import annotations
+
 import abc
 import annoworkapi  # pylint: disable=unused-import
 import warnings  # pylint: disable=unused-import

--- a/generate/partial-header/models_partial_header.py
+++ b/generate/partial-header/models_partial_header.py
@@ -9,7 +9,7 @@ enumならば列挙体として定義する。
 Note:
     このファイルはopenapi-generatorで自動生成される。
 """
-from __future__ import annotations
+
 import warnings  # pylint: disable=unused-import
 from typing import Any, Optional, Union, NewType  # pylint: disable=unused-import
 from enum import Enum


### PR DESCRIPTION
Python3.8のサポートを終了したので、`from __future__ import annotations`を除去する。